### PR TITLE
build: replace golangci-lint github action with manual install/run of golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -7,10 +7,6 @@ on:
   pull_request:
     branches: [ "**" ]
 
-
-permissions:
-  contents: read
-
 jobs:
   golangci:
     name: lint
@@ -20,7 +16,7 @@ jobs:
         with:
           go-version: 1.19.5
       - uses: actions/checkout@v3
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: latest
+      - name: install golangci-lint
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+      - name: run golangci-lint
+        run: golangci-lint run


### PR DESCRIPTION
Since the external golangci-lint GitHub action isn't allowed in this org, we can manually install and run it in our workflow.