### PR TITLE
chores: update deps, fix race in itests

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.7
+          go-version: 1.20.3
       - uses: actions/checkout@v3
       - name: install golangci-lint
         run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -9,7 +9,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   VAULT_IMAGE_NAME: nydig/vault-plugin-lndsigner
-  GO_VERSION: 1.19.7
+  GO_VERSION: 1.20.3
 
 jobs:
   # This job fetches the latest minor revision for each currently supported vault version.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG gover=1.19.7
+ARG gover=1.20.3
 
 # Build a release binary
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-ARG gover=1.19.7
+ARG gover=1.20.3
 
 FROM golang:$gover
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ ifeq ($(CPLATFORM), arm64)
 endif 
 
 GOVER         := 1.20.3
-LND           := v0.16.0-beta
+LND           := v0.16.2-beta
 BITCOIND      := 24.0.1
 VAULT         := 1.12.2
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ifeq ($(CPLATFORM), arm64)
 	CPLATFORM := aarch64
 endif 
 
-GOVER         := 1.19.7
+GOVER         := 1.20.3
 LND           := v0.16.0-beta
 BITCOIND      := 24.0.1
 VAULT         := 1.12.2

--- a/go.mod
+++ b/go.mod
@@ -88,6 +88,6 @@ replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 
 // If you change this please also update .github/pull_request_template.md and
 // docs/INSTALL.md.
-go 1.18
+go 1.20
 
 retract v0.0.2

--- a/itest/itest_lndharness_test.go
+++ b/itest/itest_lndharness_test.go
@@ -198,7 +198,6 @@ func (l *lndHarness) Close() {
 	l.tctx.t.Helper()
 
 	_ = l.Lncli("stop")
-	_ = l.lndSignerCmd.Process.Signal(os.Interrupt)
 
 	l.cancel()
 }


### PR DESCRIPTION
The first commit of this PR updates Go to 1.20.3 to match the latest `lnd` and pave the way to fixing integration test coverage measurements per #27.

Updating to go 1.20.3 exposes a [race](https://github.com/NYDIG/lndsigner/actions/runs/4866929514/jobs/8700107134#step:3:3451) in the integration tests. The following commit fixes this race by removing the line which causes it. The interrupt signal that's deleted is redundant as the command's context is canceled in the next line.

The final commit updates lnd to 0.16.2 for the itests.